### PR TITLE
scope benchmarks to their calling method to prevent collisions

### DIFF
--- a/lib/micro_bench.rb
+++ b/lib/micro_bench.rb
@@ -62,7 +62,18 @@ module MicroBench
     end
 
     def benchmark_key(bench_id = nil)
-      "#{Thread.current.object_id}||#{bench_id}"
+      "#{thread_key}||#{caller_key}||#{bench_id}"
+    end
+
+    def thread_key
+      Thread.current.object_id
+    end
+
+    def caller_key
+      caller_location = caller_locations(2..4).detect do |loc|
+        !loc.absolute_path.include?(__FILE__)
+      end
+      "#{caller_location.absolute_path}:#{caller_location.label}"
     end
   end
 end


### PR DESCRIPTION
We don't want benchmarks to collide across a given codebase. As so, we have to scope benchmarks by method.

For example :
```ruby
def method_1
  MicroBench.start
  method_2
  # Do something
  MicroBench.stop
  puts "method_1 duration : #{MicroBench.duration}"
end

def method_2
  MicroBench.start
  # Do something
  MicroBench.stop
  puts "method_2 duration : #{MicroBench.duration}"
end

method_1
```

Should output 2 separated durations for `method_1` and `method_2`.