### PR TITLE
Fix : allow referencing a benchmark from a Proc, a Block or a Lambda

### DIFF
--- a/lib/micro_bench.rb
+++ b/lib/micro_bench.rb
@@ -73,7 +73,7 @@ module MicroBench
       caller_location = caller_locations(2..4).detect do |loc|
         !loc.absolute_path.include?(__FILE__)
       end
-      "#{caller_location.absolute_path}:#{caller_location.label}"
+      "#{caller_location.absolute_path}:#{caller_location.base_label}"
     end
   end
 end

--- a/spec/micro_bench/micro_bench_spec.rb
+++ b/spec/micro_bench/micro_bench_spec.rb
@@ -90,4 +90,24 @@ describe MicroBench do
     expect(subject.method_1_duration).to_not eq(subject.method_2_duration)
   end
 
+  it "allows referencing a benchmark from a Proc / Block / Lambda" do
+    MicroBench.start
+    # from a Proc
+    proc = Proc.new do
+      expect(MicroBench.duration).to_not be_nil
+    end
+    proc.call
+    # from a Block
+    def my_method
+      yield
+    end
+    my_method do
+      expect(MicroBench.duration).to_not be_nil
+    end
+    # from a Lambda
+    l = lambda do
+      expect(MicroBench.duration).to_not be_nil
+    end
+    l.call
+  end
 end


### PR DESCRIPTION
We should be able to reference a benchmark from a Proc, a block or a lambda. This is essential when doing something like this (to avoid log overhead in non-targeted environments) : 

```ruby
MicroBench.start
# ... Do something heavy
Rails.logger.info do
  "Duration : #{MicroBench.duration}"
end
```