### PR TITLE
Add a `formatter` configuration

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--color --require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # Override Klaxit remote Rubocop config
 # See https://github.com/klaxit/ruby/rubocop.yml
 inherit_from:
-  - https://raw.githubusercontent.com/klaxit/ruby/master/rubocop.yml
+  - https://git.io/klaxit-rubocop
 
 AllCops:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "http://rubygems.org"
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -124,6 +124,31 @@ end
 method_1
 ```
 
+### Configuration
+
+You can configure a bit `MicroBench` to have an even simpler time using it afterwards. Here's how:
+
+```ruby
+MicroBench.configure do |config|
+  config.formatter = ->(duration) { "#{duration.round} seconds" }
+end
+
+MicroBench.start
+sleep 2
+MicroBench.duration == "2 seconds"
+```
+
+There are some default formatters that you can set:
+
+| id        | result                       | description                              |
+| --------- | ---------------------------- | ---------------------------------------- |
+| `default` | `722.327823832`              | the raw original float, for computation  |
+| `simple`  | `722.33`                     | rounds to 2 digits                       |
+| `mmss`    | `"12:02.328"`                | Easy to understand, lossless and compact |
+| `human`   | `"12 minutes and 2 seconds"` | For humans, clutters logs                |
+
+To use one of those, simply write `config.formatter = :simple` instead of a lambda.
+
 ## Versioning
 
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/klaxit/micro_bench/tags).

--- a/lib/micro_bench.rb
+++ b/lib/micro_bench.rb
@@ -1,5 +1,18 @@
+# frozen_string_literal: true
+
 module MicroBench
   class << self
+    # Configure MicroBench.
+    #
+    # == Example usage:
+    #   MicroBench.configure do |config|
+    #     config.formatter = proc { |duration| duration.ceil }
+    #   end
+    def configure(&block)
+      block.call(configurations)
+      nil
+    end
+
     # Start a benchmark
     #
     # == Parameters:
@@ -52,10 +65,16 @@ module MicroBench
     #   MicroBench.stop(:my_benchmark)
     #
     def duration(bench_id = nil)
-      benchmarks[benchmark_key(bench_id)]&.duration
+      configurations.formatter.call(
+        benchmarks[benchmark_key(bench_id)]&.duration
+      )
     end
 
     private
+
+    def configurations
+      @configurations ||= Configurations.new
+    end
 
     def benchmarks
       @benchmarks ||= {}
@@ -79,3 +98,4 @@ module MicroBench
 end
 
 require "micro_bench/benchmark"
+require "micro_bench/configurations"

--- a/lib/micro_bench/benchmark.rb
+++ b/lib/micro_bench/benchmark.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MicroBench::Benchmark
   def initialize
     @start_time = monotonic_clock_time

--- a/lib/micro_bench/configurations.rb
+++ b/lib/micro_bench/configurations.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+class MicroBench::Configurations
+  attr_reader :formatter
+
+  # Initialize with a default formatters that changes nothing.
+  def initialize
+    @formatter = method(:default_formatter)
+  end
+
+  # Set formatter to change {MicroBench.duration} results.
+  #
+  # == Parameters:
+  # value::
+  #   It can be a proc that receives a duration float in seconds and returns any
+  #   formatted value. Or it can be one of the default values, +"simple"+,
+  #   +"mmss"+ or +"human"+. If you set it to +nil+ or +"default"+, the
+  #   formatter will be ignored, and the result will be the raw float.
+  def formatter=(value)
+    # This ensures that both Proc and Method can be used there. Or even a user
+    # defined class that responds to call.
+    if value.respond_to?(:call)
+      @formatter = value
+      return
+    end
+
+    formatter_method =
+      case value.to_s
+      when "", "default"
+        :default_formatter
+      when "simple"
+        :simple_formatter
+      when "mmss"
+        :mmss_formatter
+      when "human"
+        :human_formatter
+      else
+        raise ArgumentError, "formatter must be callable or a default string"
+      end
+
+    @formatter = method(formatter_method)
+  end
+
+  private
+
+  def default_formatter(duration)
+    duration
+  end
+
+  def simple_formatter(duration)
+    duration.round(2)
+  end
+
+  def mmss_formatter(duration)
+    ss, ms = duration.divmod(1)
+    mm, ss = ss.divmod(60)
+    hh, mm = mm.divmod(60)
+
+    # Format ms to have only 3 digits.
+    ms = (ms * 1_000).round
+
+    return format("%02d:%02d:%02d.%03d", hh, mm, ss, ms) if hh > 0
+    return format("%02d:%02d.%03d", mm, ss, ms) if mm > 0
+    return format("%d.%03d", ss, ms)
+  end
+
+  def human_formatter(duration)
+    ss = duration.round
+    mm, ss = ss.divmod(60)
+    hh, mm = mm.divmod(60)
+
+    human_unit = ->(value, name) { "#{value} #{name}#{"s" unless value == 1}" }
+
+    hours   = human_unit[hh, "hour"]
+    minutes = human_unit[mm, "minute"]
+    seconds = human_unit[ss, "second"]
+
+    human_join = ->(*array) { array[0..-2].join(", ") + " and #{array.last}" }
+
+    return human_join[hours, minutes, seconds] if hh > 0
+    return human_join[minutes, seconds] if mm > 0
+    return seconds
+  end
+end

--- a/lib/micro_bench/version.rb
+++ b/lib/micro_bench/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module MicroBench
-  VERSION = "0.1.3".freeze
+  VERSION = "0.1.3"
 end

--- a/lib/micro_bench/version.rb
+++ b/lib/micro_bench/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MicroBench
-  VERSION = "0.1.3"
+  VERSION = "0.2.3"
 end

--- a/micro_bench.gemspec
+++ b/micro_bench.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.push File.expand_path("lib", __dir__)
 require "micro_bench/version"
 

--- a/spec/micro_bench/configurations_spec.rb
+++ b/spec/micro_bench/configurations_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe MicroBench::Configurations do
+  let(:duration) { rand(10) + rand }
+
+  describe "#default_formatter" do
+    it "does nothing" do
+      expect(subject.send(:default_formatter, duration)).to eq duration
+    end
+  end
+
+  describe "#simple_formatter" do
+    it "rounds" do
+      expect(subject.send(:simple_formatter, duration)).to eq duration.round(2)
+    end
+  end
+
+  describe "#mmss_formatter" do
+    it "gives hh:mm:ss.s" do
+      expect(subject.send(:mmss_formatter, 457927.127)).to eq "127:12:07.127"
+    end
+  end
+
+  describe "#human_formatter" do
+    it "gives a text" do
+      expect(subject.send(:human_formatter, 457287.4699882))
+        .to eq "127 hours, 1 minute and 27 seconds"
+    end
+  end
+end

--- a/spec/micro_bench_spec.rb
+++ b/spec/micro_bench_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+# frozen_string_literal: true
 
 describe MicroBench do
   it "gives seconds duration doing something" do
@@ -91,10 +91,10 @@ describe MicroBench do
   end
 
   it "allows referencing a benchmark from a Proc / Block / Lambda" do
-    MicroBench.start
+    described_class.start
     # from a Proc
     proc = Proc.new do
-      expect(MicroBench.duration).to_not be_nil
+      expect(described_class.duration).to_not be_nil
     end
     proc.call
     # from a Block
@@ -102,12 +102,28 @@ describe MicroBench do
       yield
     end
     my_method do
-      expect(MicroBench.duration).to_not be_nil
+      expect(described_class.duration).to_not be_nil
     end
     # from a Lambda
     l = lambda do
-      expect(MicroBench.duration).to_not be_nil
+      expect(described_class.duration).to_not be_nil
     end
     l.call
+  end
+
+  it "formats duration when configured with an id" do
+    described_class.configure do |config|
+      config.formatter = :human
+    end
+    described_class.start
+    expect(described_class.duration).to eq "0 seconds"
+  end
+
+  it "formats duration when using a callable" do
+    described_class.configure do |config|
+      config.formatter = proc { "result" }
+    end
+    described_class.start
+    expect(described_class.duration).to eq "result"
   end
 end


### PR DESCRIPTION
This will allow to avoid repetition of `round(2)` in our codebase.

```ruby
MicroBench.configure do |config|
  config.formatter = :simple
end
MicroBench.start
# wait exactly 1.12743 seconds
MicroBench.duration == 1.13
```