### PR TITLE
Add raw_duration method

### DIFF
--- a/lib/micro_bench.rb
+++ b/lib/micro_bench.rb
@@ -59,15 +59,32 @@ module MicroBench
     #   Identifier of the benchmark
     #
     # == Returns:
-    # Duration of the given benchmark, or nil if benchmark is unknown
+    # Formatted duration of the given benchmark, or nil if benchmark is unknown.
     #
     # == Example usage:
-    #   MicroBench.stop(:my_benchmark)
+    #   MicroBench.duration(:my_benchmark)
     #
     def duration(bench_id = nil)
-      configurations.formatter.call(
-        benchmarks[benchmark_key(bench_id)]&.duration
-      )
+      raw = raw_duration(bench_id)
+      return nil if raw.nil?
+      
+      configurations.formatter.call(raw)
+    end
+
+    # Give raw duration of the benchmark
+    #
+    # == Parameters:
+    # bench_id::
+    #   Identifier of the benchmark
+    #
+    # == Returns:
+    # Duration of the given benchmark, or nil if benchmark is unknown.
+    #
+    # == Example usage:
+    #   MicroBench.raw_duration(:my_benchmark)
+    #
+    def raw_duration(bench_id = nil)
+      benchmarks[benchmark_key(bench_id)]&.duration
     end
 
     private

--- a/spec/micro_bench_spec.rb
+++ b/spec/micro_bench_spec.rb
@@ -126,4 +126,9 @@ describe MicroBench do
     described_class.start
     expect(described_class.duration).to eq "result"
   end
+
+  it "gives raw duration" do
+    described_class.start
+    expect(described_class.raw_duration).to be_a Float
+  end
 end


### PR DESCRIPTION
Because sometimes, the raw value is needed for computation. Example:

```ruby
durations = []
10.times do
  MicroBench.start
  measured_method
  durations << MicroBench.raw_duration
end

puts "method avg is #{durations.reduce(0, :+) / 10.0}s"