### PR TITLE
Remove support for Ruby < 2.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](http://keepachangelog.com/).
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+
+## [Unreleased]
+
+### Added
+
+- This changelog
+
+### Changed
+
+- Remove support for Ruby before 2.4.6.
+
+### Fixed
+
+[unreleased]: https://github.com/klaxit/fast-polylines/compare/v0.3.0...HEAD

--- a/micro_bench.gemspec
+++ b/micro_bench.gemspec
@@ -3,20 +3,20 @@
 $LOAD_PATH.push File.expand_path("lib", __dir__)
 require "micro_bench/version"
 
-Gem::Specification.new do |s|
-  s.name        = "micro_bench"
-  s.version     = MicroBench::VERSION
-  s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Cyrille Courtière"]
-  s.email       = ["cyrille@klaxit.com"]
-  s.homepage    = "http://github.com/klaxit/micro_bench"
-  s.summary     = "Dead simple benchmarks"
-  s.license     = "MIT"
+Gem::Specification.new do |spec|
+  spec.name        = "micro_bench"
+  spec.version     = MicroBench::VERSION
+  spec.platform    = Gem::Platform::RUBY
+  spec.authors     = ["Cyrille Courtière"]
+  spec.email       = ["cyrille@klaxit.com"]
+  spec.homepage    = "http://github.com/klaxit/micro_bench"
+  spec.summary     = "Dead simple benchmarks"
+  spec.license     = "MIT"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.6")
 
-  s.files = `git ls-files -- lib/*`.split("\n")
-  s.files += %w(README.md)
-  s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.require_paths = "lib"
+  spec.files = Dir["lib/**/*.rb"] + %w(README.md CHANGELOG.md)
+  spec.test_files = Dir["spec/**/*"] + %w(.rspec)
+  spec.require_paths = "lib"
 
   s.add_development_dependency("byebug", "~> 9.0")
   s.add_development_dependency("rspec", "~> 3.8")

--- a/micro_bench.gemspec
+++ b/micro_bench.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version     = MicroBench::VERSION
   spec.platform    = Gem::Platform::RUBY
   spec.authors     = ["Cyrille Courtière"]
-  spec.email       = ["cyrille@klaxit.com"]
+  spec.email       = ["dev@klaxit.com"]
   spec.homepage    = "http://github.com/klaxit/micro_bench"
   spec.summary     = "Dead simple benchmarks"
   spec.license     = "MIT"
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files = Dir["spec/**/*"] + %w(.rspec)
   spec.require_paths = "lib"
 
-  s.add_development_dependency("byebug", "~> 9.0")
-  s.add_development_dependency("rspec", "~> 3.8")
+  spec.add_development_dependency("byebug", "~> 9.0")
+  spec.add_development_dependency("rspec", "~> 3.8")
 end


### PR DESCRIPTION
Fixes #5

I've also normalized the gemspec based on fast-polylines, and added a changelog.